### PR TITLE
update url relative to current scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
 
 <table id="feed" class="table table-striped">  </table>
-<script src="http://cdn.pubnub.com/pubnub.min.js"></script>
+<script src="//cdn.pubnub.com/pubnub.min.js"></script>
 <script>
     function createTable(json) {
         var table = document.getElementById("feed");


### PR DESCRIPTION
since forever, most browsers dont allow scripts to be loaded when origin scheme is secured but scripts' scheme is not.

this patch fixes that problem